### PR TITLE
Implement authentication against an oidc provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ You can configure caluma_interval with environment variables or CLI arguments, w
 Cli arguments take precedence.
 
 ```
-usage: __main__.py [-h] [-c STRING] [-d] [-v]
+usage: __main__.py [-h] [-c STRING] [-i STRING] [-s STRING] [-u STRING] [-d]
+                   [-v]
 
 Caluma companion app for handling intervalled forms
 
@@ -115,15 +116,30 @@ optional arguments:
   -h, --help            show this help message and exit
   -c STRING, --caluma-uri STRING
                         defaults to "http://caluma:8000/graphql"
+  -i STRING, --oidc-client-id STRING
+  -s STRING, --oidc-client-secret STRING
+  -u STRING, --oidc-token-uri STRING
   -d, --debug           print debug messages
   -v, --version         show program's version number and exit
 ```
 
 The corresponding environment varibles are:
  * CALUMA_URI
+ * OIDC_CLIENT_ID
+ * OIDC_CLIENT_SECRET
+ * OIDC_TOKEN_URI
+
+To enable oidc authentication over plain http (only for testing!), set
+`OAUTHLIB_INSECURE_TRANSPORT` to `1`.
 
 
-## TODO: authorization
+## Authentication
+As caluma uses OpenID Connect (OIDC), we need to fetch a token from the OIDC provider.
+
+For this you have to provide a client id, client secret and a token uri.
+
+If none of them are provided, the client will make unauthenticated request, which
+(hopefully) will fail in your prod setup.
 
 ## ValidationClass
 

--- a/caluma_interval/client.py
+++ b/caluma_interval/client.py
@@ -1,11 +1,57 @@
 import json
+import logging
+from datetime import datetime, timedelta
 
 import requests
+from envparse import env
+from oauthlib.oauth2 import BackendApplicationClient
+from requests_oauthlib import OAuth2Session
+
+logger = logging.getLogger(__name__)
 
 
 class CalumaClient:
-    def __init__(self, endpoint):
+    def __init__(
+        self,
+        endpoint=env("CALUMA_URI", default="http://caluma/graphql"),
+        oidc_client_id=env("OIDC_CLIENT_ID", default=None),
+        oidc_client_secret=env("OIDC_CLIENT_SECRET", default=None),
+        oidc_token_uri=env("OIDC_TOKEN_URI", default=None),
+    ):
         self.endpoint = endpoint
+        self.oidc_client_id = oidc_client_id
+        self.oidc_client_secret = oidc_client_secret
+        self.oidc_token_uri = oidc_token_uri
+
+        self._token = None
+
+    def get_token(self):
+        """
+        If needed fetch a (new) token from the oidc provider.
+
+        The threshold for fetching a new token is 1 minute before expiration.
+
+        :return: dict
+        """
+        if not all([self.oidc_client_id, self.oidc_client_secret, self.oidc_token_uri]):
+            logger.warning("Auth disabled due to missing parameters!")
+            return
+
+        thresh = datetime.now() + timedelta(minutes=1)
+
+        if self._token is None or self._token["expires_at_dt"] <= thresh:
+            client = BackendApplicationClient(client_id=self.oidc_client_id)
+            oauth = OAuth2Session(client=client)
+            self._token = oauth.fetch_token(
+                token_url=self.oidc_token_uri,
+                client_id=self.oidc_client_id,
+                client_secret=self.oidc_client_secret,
+            )
+            self._token["expires_at_dt"] = datetime.utcfromtimestamp(
+                int(self._token["expires_at"])
+            )
+
+        return self._token
 
     def execute(self, query, variables=None):
         return self._send(query, json.dumps(variables))
@@ -14,9 +60,9 @@ class CalumaClient:
         data = {"query": query, "variables": variables}
         headers = {"Accept": "application/json", "Content-Type": "application/json"}
 
-        try:
-            response = requests.post(self.endpoint, data, headers)
-            return response.json()
-        except requests.exceptions.RequestException as e:
-            print(e)
-            raise e
+        token = self.get_token()
+        if token:
+            headers["Authorization"] = f"Bearer {token['access_token']}"
+
+        response = requests.post(self.endpoint, data, headers)
+        return response.json()

--- a/caluma_interval/interval.py
+++ b/caluma_interval/interval.py
@@ -12,20 +12,35 @@ logger = logging.getLogger(__name__)
 
 __title__ = "caluma_interval"
 __description__ = "Caluma companion app for handling intervalled forms"
-__version__ = "1.0.0"
+__version__ = "0.0.1"
 __author__ = "Adfinis SyGroup"
 
 
 class IntervalManager:
-    def __init__(self, caluma_uri=env("CALUMA_URI", default="http://caluma/graphql")):
+    def __init__(
+        self,
+        caluma_uri=env("CALUMA_URI", default="http://caluma/graphql"),
+        oidc_client_id=env("OIDC_CLIENT_ID", default=None),
+        oidc_client_secret=env("OIDC_CLIENT_SECRET", default=None),
+        oidc_token_uri=env("OIDC_TOKEN_URI", default=None),
+    ):
         self.caluma_uri = caluma_uri
+        self.oidc_client_id = oidc_client_id
+        self.oidc_client_secret = oidc_client_secret
+        self.oidc_token_uri = oidc_token_uri
+
         self._client = None
         self.action_count = 0
 
     @property
     def client(self):
         if not self._client:
-            self._client = CalumaClient(self.caluma_uri)
+            self._client = CalumaClient(
+                self.caluma_uri,
+                self.oidc_client_id,
+                self.oidc_client_secret,
+                self.oidc_token_uri,
+            )
         return self._client
 
     def get_intervalled_forms(self):

--- a/caluma_interval/tests/conftest.py
+++ b/caluma_interval/tests/conftest.py
@@ -1,10 +1,11 @@
 import sys
+from datetime import datetime
 
 import pytest
 
 import psycopg2
-
-from .interval import IntervalManager
+from caluma_interval.client import CalumaClient
+from caluma_interval.interval import IntervalManager
 
 
 @pytest.fixture
@@ -13,8 +14,30 @@ def manager():
 
 
 @pytest.fixture
-def client(manager):
-    return manager.client
+def client():
+    return CalumaClient(endpoint="http://caluma:8000/graphql")
+
+
+@pytest.fixture
+def auth_client():
+    return CalumaClient(
+        endpoint="http://caluma:8000/graphql",
+        oidc_client_id="id",
+        oidc_client_secret="secret",
+        oidc_token_uri="uri",
+    )
+
+
+@pytest.fixture()
+def token():
+    return {
+        "access_token": "6c7dfa20995640c28e0eba82c5c88271",
+        "expires_in": 300,
+        "token_type": "bearer",
+        "scope": ["caluma"],
+        "expires_at": 1553154201.6981535,
+        "expires_at_dt": datetime(2019, 3, 21, 7, 43, 21),
+    }
 
 
 @pytest.fixture

--- a/caluma_interval/tests/test_cli.py
+++ b/caluma_interval/tests/test_cli.py
@@ -19,3 +19,9 @@ def test_main(sys_argv_handler, create_form_to_workflow, cleanup_db):
 
     sys.argv = ["__main__.py", "-c", "http://caluma:8000/graphql"]
     main()
+
+
+def test_main_failure(sys_argv_handler, create_form_to_workflow, cleanup_db, caplog):
+    sys.argv = ["__main__.py", "-c", "http://nothing-here", "-d"]
+    main()
+    assert caplog.records[-1].levelname == "ERROR"

--- a/caluma_interval/tests/test_client.py
+++ b/caluma_interval/tests/test_client.py
@@ -1,8 +1,46 @@
 import pytest
 from requests.exceptions import MissingSchema
+from requests_oauthlib import OAuth2Session
+
+from caluma_interval.queries import intervalled_forms_query
+
+
+def test_use_client(client):
+    query = """\
+query allForms {
+  allForms{
+    pageInfo {
+      startCursor
+      endCursor
+    }
+    edges {
+      node {
+        name
+        meta
+      }
+    }
+  }
+}\
+"""
+
+    resp = client.execute(query)
+    assert "allForms" in resp["data"]
 
 
 def test_client_exception(client):
     client.endpoint = "not a uri"
     with pytest.raises(MissingSchema):
         client.execute("not a query")
+
+
+def test_get_token(mocker, auth_client, token):
+    mocker.patch.object(OAuth2Session, "fetch_token")
+    OAuth2Session.fetch_token.return_value = token
+    assert auth_client.get_token() == token
+
+
+def test_authenticated_request(mocker, auth_client, token):
+    mocker.patch.object(OAuth2Session, "fetch_token")
+    OAuth2Session.fetch_token.return_value = token
+    auth_client.execute(intervalled_forms_query)
+    OAuth2Session.fetch_token.assert_called()

--- a/caluma_interval/tests/test_interval.py
+++ b/caluma_interval/tests/test_interval.py
@@ -3,28 +3,6 @@ from datetime import date, timedelta
 from isodate.duration import Duration
 
 
-def test_use_client(client):
-    query = """\
-query allForms {
-  allForms{
-    pageInfo {
-      startCursor
-      endCursor
-    }
-    edges {
-      node {
-        name
-        meta
-      }
-    }
-  }
-}\
-"""
-
-    resp = client.execute(query)
-    assert "allForms" in resp["data"]
-
-
 def test_get_intervalled_forms(manager, create_forms, cleanup_db):
     forms = manager.get_intervalled_forms()
     assert len(forms) == 2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,9 @@ black==18.9b0
 flake8==3.7.7
 ipython==7.3.0
 isort==4.3.15
+mock==2.0.0
 pre-commit==1.14.4
 psycopg2-binary==2.7.7
 pytest==4.3.1
 pytest-cov==2.6.1
+pytest-mock==1.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 envparse==0.2.0
 isodate==0.6.0
 requests==2.21.0
+requests-oauthlib==1.2.0


### PR DESCRIPTION
This commit adds following functionality to the CalumaClient:

 * fetching a token from an oidc provider
 * sending the token in a request header
 * automagically renew the token if needed

Other changes in this commit:

 * move conftest.py to caluma_interval/tests/
 * corrected wrong version in interval.py