### PR TITLE
Use the regex we claim to be using in the README

### DIFF
--- a/caluma_interval/tests/test_cli.py
+++ b/caluma_interval/tests/test_cli.py
@@ -21,6 +21,37 @@ def test_main(sys_argv_handler, create_form_to_workflow, cleanup_db):
     main()
 
 
+def test_main_faulty_interval(
+    client, sys_argv_handler, create_form_to_workflow, cleanup_db
+):
+    """
+    Test handling of faulty intervals.
+
+    We just want to know if this runs through without throwing any exception.
+
+    This should never be needed, as Calumas ValidationClass should already
+    enforce this.
+
+    Nonetheless, here's the test:
+    """
+    query = """\
+        mutation MyForm {
+          firstIntSave: saveForm (input: {
+            slug: "my-first-interval-form",
+            name: "my first interval Form"
+            meta: "{\\"interval\\": {\\"interval\\": \\"2018-03-01/P2Wpqli\\", \\"workflow_slug\\": \\"my-test-workflow\\"}}"
+          }) {
+            form {
+              slug
+            }
+          }
+        }\
+    """
+    client.execute(query)
+    sys.argv = ["__main__.py", "-d"]
+    main()
+
+
 def test_main_failure(sys_argv_handler, create_form_to_workflow, cleanup_db, caplog):
     sys.argv = ["__main__.py", "-c", "http://nothing-here", "-d"]
     main()


### PR DESCRIPTION
We just use the date part of the ISO8601 period expression. The proper regex
for validating it is already in the ValidatorClass for Caluma in our README.

With this commit, we're actually using this regex to validate the
provided interval.

This commit also refactors the whole interval parsing and it's corresponding
tests.