### PR TITLE
Set Caluma-Companion header

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,21 @@ class FormIntervalValidation(BaseValidation):
         validate_interval(interval['interval'])
 ```
 
+## VisibilityClass
+
+Make sure, that caluma-interval has access to `Forms`, `Documents` and `Cases`.
+
+```python
+class MyVisibility(BaseVisibility):
+    @filter_queryset_for(Node)
+    def filter_queryset(self, node, queryset, info):
+        if info.context.META.get(
+            "HTTP_CALUMA_COMPANION", None
+        ) == "interval" and node in [Form, Document, Case]:
+            return queryset
+```
+
+
 ## docker-compose integration
 
 ```

--- a/caluma_interval/client.py
+++ b/caluma_interval/client.py
@@ -58,7 +58,11 @@ class CalumaClient:
 
     def _send(self, query, variables):
         data = {"query": query, "variables": variables}
-        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Caluma-Companion": "interval",
+        }
 
         token = self.get_token()
         if token:

--- a/caluma_interval/tests/test_client.py
+++ b/caluma_interval/tests/test_client.py
@@ -53,6 +53,7 @@ def test_authenticated_request(mocker, auth_client, token):
         {
             "Accept": "application/json",
             "Content-Type": "application/json",
+            "Caluma-Companion": "interval",
             "Authorization": f"Bearer {token['access_token']}",
         },
     )


### PR DESCRIPTION
In order to configure visibilities for caluma-interval, we set a custom header:

"Caluma-Companion: interval"