### PR TITLE
fix(intervalmanager): handle omitted start date

### DIFF
--- a/caluma_interval/interval.py
+++ b/caluma_interval/interval.py
@@ -146,14 +146,16 @@ class IntervalManager:
         return dt + timedelta(days=gap)
 
     def needs_action(self, last_run, interval, start, weekday=None):
-        now = date.today()
-        if start > now:
+        today = date.today()
+        if start is None:
+            start = today
+        if start > today:
             return False
         next_run = last_run + interval
         if weekday is not None:
             if not next_run.weekday() == weekday:
                 next_run = self.get_last_weekday(next_run, weekday)
-        if next_run < now:
+        if next_run < today:
             return True
 
     def handle_form(self, form):

--- a/caluma_interval/tests/test_interval.py
+++ b/caluma_interval/tests/test_interval.py
@@ -126,3 +126,6 @@ def test_needs_action(manager):
 
     kwargs["start"] = date.today() + timedelta(days=5)
     assert not manager.needs_action(**kwargs)
+
+    kwargs["start"] = None
+    assert manager.needs_action(**kwargs)


### PR DESCRIPTION
This commit ensures that without a set start date, today is assumed.

Closes #64