### PR TITLE
fix(intervalmanager): handle Exceptions

### DIFF
--- a/caluma_interval/interval.py
+++ b/caluma_interval/interval.py
@@ -174,5 +174,8 @@ class IntervalManager:
         forms = self.get_intervalled_forms()
         logger.info(f"Got {len(forms)} intervalled forms from caluma.")
         for form in forms:
-            self.handle_form(form["node"])
+            try:
+                self.handle_form(form["node"])
+            except Exception:
+                logger.exception(f"Couldn't process form \"{form['node']['slug']}\"!")
         logger.info(f"Started {self.action_count} case(s).")

--- a/caluma_interval/tests/test_interval.py
+++ b/caluma_interval/tests/test_interval.py
@@ -3,6 +3,8 @@ from datetime import date, timedelta
 import pytest
 from isodate.duration import Duration
 
+from ..interval import IntervalManager
+
 
 def test_get_intervalled_forms(manager, create_forms, cleanup_db):
     forms = manager.get_intervalled_forms()
@@ -129,3 +131,10 @@ def test_needs_action(manager):
 
     kwargs["start"] = None
     assert manager.needs_action(**kwargs)
+
+
+def test_fail_processing(mocker, manager, create_form_to_workflow, cleanup_db):
+    mocker.patch.object(IntervalManager, "handle_form")
+    IntervalManager.handle_form.side_effect = Exception
+    # No exception should be raised
+    manager.run()


### PR DESCRIPTION
This commit makes sure that any Exception raised during processing of a
form is handled and logged in order to not prevent processing of other
forms.

Closes #67