### PR TITLE
fix(caluma): update caluma

### DIFF
--- a/caluma_interval/tests/conftest.py
+++ b/caluma_interval/tests/conftest.py
@@ -127,16 +127,16 @@ def cleanup_db():
     cur = conn.cursor()
     fmt_str = "DELETE FROM {};"
     tables = [
-        "workflow_workitem",
-        "workflow_case",
-        "form_document",
-        "form_form",
-        "workflow_taskflow",
-        "workflow_flow",
-        "workflow_workflow_start_tasks",
-        "workflow_workflow_allow_forms",
-        "workflow_task",
-        "workflow_workflow",
+        "caluma_workflow_workitem",
+        "caluma_workflow_case",
+        "caluma_form_document",
+        "caluma_form_form",
+        "caluma_workflow_taskflow",
+        "caluma_workflow_flow",
+        "caluma_workflow_workflow_start_tasks",
+        "caluma_workflow_workflow_allow_forms",
+        "caluma_workflow_task",
+        "caluma_workflow_workflow",
     ]
     for table in tables:
         delete_sql = fmt_str.format(table)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     command: -p ${DATABASE_PORT:-5432}
 
   caluma:
-    image: projectcaluma/caluma:latest@sha256:e281803cb8c6592889aca9c1bcd4b649f9f4c3f2aaba8d6698dd2af11e2076ac
+    image: projectcaluma/caluma:latest@sha256:5b0a2c2950a6a8c9ff6a6c0a85cf6cc67fc56948b1dec518dca69c6ee817b114
     ports:
       - "8000:8000"
     depends_on:
@@ -27,8 +27,8 @@ services:
       - SECRET_KEY=uuuuuu
       - ALLOWED_HOSTS=*
       - DATABASE_PASSWORD=caluma
-      - VISIBILITY_CLASSES=caluma.core.visibilities.Any
-      - PERMISSION_CLASSES=caluma.core.permissions.AllowAny
+      - VISIBILITY_CLASSES=caluma.caluma_core.visibilities.Any
+      - PERMISSION_CLASSES=caluma.caluma_core.permissions.AllowAny
 
 volumes:
   dbdata:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,12 @@
 -r requirements.txt
 black==18.9b0
 flake8==3.7.9
-ipython==7.9.0
+ipython==7.12.0
 isort==4.3.21
 mock==3.0.5
-pre-commit==1.20.0
+pre-commit==2.0.1
 psycopg2-binary==2.8.4
-pytest==5.3.0
+pytest==5.3.5
 pytest-cov==2.8.1
-pytest-mock==1.12.1
-python-semantic-release==4.3.3
+pytest-mock==2.0.0
+python-semantic-release==4.4.0


### PR DESCRIPTION
Since caluma version 5.0.0, all apps and tables are prefixed with
`caluma_`.

This commit applies those changes.