### PR TITLE
chore(dev): commit lint instead of node-based check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,3 @@ target/
 
 # IDE specific configurations
 .idea/
-
-# npm
-node_modules/
-package-lock.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,17 +2,26 @@ repos:
 -   repo: local
     hooks:
     - id: black
+      stages: [commit]
       name: black
       language: system
       entry: black
       types: [python]
     - id: isort
+      stages: [commit]
       name: isort
       language: system
       entry: isort -y
       types: [python]
     - id: flake8
+      stages: [commit]
       name: flake8
       language: system
       entry: flake8
       types: [python]
+    - id: gitlint
+      stages: [commit-msg]
+      name: gitlint
+      description: Validate commit lint
+      entry: gitlint --msg-filename
+      language: system

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,17 +28,12 @@ jobs:
         - while sudo lsof -Pi :5432 -sTCP:LISTEN -t; do sleep 1; done
       install:
         - docker-compose up -d --build
-        - npm install @commitlint/{config-conventional,travis-cli}
+        - pip install $(grep "gitlint" ./requirements-dev.txt)
       script:
         - docker-compose up -d db caluma
         - docker-compose run --rm interval black --check .
         - docker-compose run --rm interval flake8
-        - ./node_modules/.bin/commitlint-travis
+        - gitlint --commits ${TRAVIS_BRANCH}..HEAD lint
         - docker-compose run --rm interval wait-for-it.sh db:5432
         - docker-compose run --rm interval wait-for-it.sh caluma:8000
         - docker-compose run --rm interval pytest --no-cov-on-fail --cov
-      after_success:
-        - git config --global user.name "semantic-release (via TravisCI)"
-        - git config --global user.email "semantic-release@travis"
-        - pip install python-semantic-release
-        - semantic-release publish

--- a/README.md
+++ b/README.md
@@ -244,12 +244,6 @@ First create a virtualenv with the tool of your choice before running below comm
 pip install pre-commit
 pip install -r requirements-dev.txt -U
 pre-commit install
-```
-
-### commit-msg hook
-If you want to have your commit message automatically linted, execute below commands:
-
-```bash
-npm install @commitlint/{config-conventional,cli}
-ln -s "$(pwd)/commit-msg" .git/hooks/commit-msg
+pre-commit install --hook=pre-commit
+pre-commit install --hook=commit-msg
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 black==18.9b0
 flake8==3.7.9
+gitlint==0.12.0
 ipython==7.12.0
 isort==4.3.21
 mock==3.0.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,8 +46,3 @@ exclude_lines =
 omit=
     setup.py
 show_missing = True
-
-[semantic_release]
-version_variable=caluma_interval/interval_metadata.py:__version__
-branch=release
-upload_to_pypi=False


### PR DESCRIPTION
Avoid installing node modules during install, use a python-based
linter instead.